### PR TITLE
Fixes parsing of @timestamp for Elasticsearch Audit JSON logs

### DIFF
--- a/filebeat/module/elasticsearch/audit/ingest/pipeline-json.json
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline-json.json
@@ -196,9 +196,21 @@
                 "field": "elasticsearch.audit.@timestamp",
                 "target_field": "@timestamp",
                 "formats": [
-                    "ISO8601"
+                    "yyyy-MM-dd'T'HH:mm:ss,SSS"
                 ],
                 "ignore_failure": true
+            }
+        },
+        {
+            "date": {
+                "if": "ctx.event.timezone != null",
+                "field": "elasticsearch.audit.@timestamp",
+                "target_field": "@timestamp",
+                "formats": [
+                    "yyyy-MM-dd'T'HH:mm:ss,SSS"
+                ],
+                "timezone": "{{ event.timezone }}",
+                "on_failure": [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
             }
         }
     ],


### PR DESCRIPTION
Fixes parsing of @timestamp for Elasticsearch Audit JSON logs.

E.g. of audit JSON logs:
```
{"@timestamp":"2019-09-05T14:02:37,921", "node.id":"UwRu4mReRtyJO1-FWAPvIQ", "event.type":"transport", "event.action":"authentication_success", "user.name":"_system", "origin.type":"local_node", "origin.address":"127.0.0.1:9300", "realm":"__fallback", "request.id":"474ZciqtQteOhjLO3OdZIw", "action":"indices:monitor/stats", "request.name":"IndicesStatsRequest"}
```

Related to https://github.com/elastic/beats/pull/13367